### PR TITLE
feat: add multi manifest file support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 clean:
 	rm -rf ./bin
 
+test:
+	go test ./...
+
 build:
 	rm -f bin/*
 	env GOOS=linux go build -ldflags="-s -w" -o bin/lambda backend/endpoints/aws/lambda.go

--- a/backend/api/kubeneat/kubeneat_test.go
+++ b/backend/api/kubeneat/kubeneat_test.go
@@ -1,0 +1,43 @@
+package kubeneat
+
+import (
+	"gotest.tools/assert"
+	"os"
+	"testing"
+)
+
+func TestSingleManifest(t *testing.T) {
+	t.Run("Test Single Manifest", func(t *testing.T) {
+		manifest, err := os.ReadFile("testdata/single_manifest.yaml")
+		if err != nil {
+			t.Errorf("Error reading manifest file: %s", err)
+		}
+		expectedManifest, err := os.ReadFile("testdata/expected/single_manifest.yaml")
+		if err != nil {
+			t.Errorf("Error reading manifest file: %s", err)
+		}
+		wrapper, _, err := NeatYAMLOrJSONWrapper(manifest)
+		if err != nil {
+			t.Errorf("Error parsing manifest: %s", err)
+		}
+		assert.Equal(t, string(expectedManifest), string(wrapper))
+	})
+}
+
+func TestMultiManifest(t *testing.T) {
+	t.Run("Test Multi Manifest yaml", func(t *testing.T) {
+		manifest, err := os.ReadFile("testdata/multi_manifest.yaml")
+		if err != nil {
+			t.Errorf("Error reading manifest file: %s", err)
+		}
+		expectedManifest, err := os.ReadFile("testdata/expected/multi_manifest.yaml")
+		if err != nil {
+			t.Errorf("Error reading manifest file: %s", err)
+		}
+		wrapper, _, err := NeatYAMLOrJSONWrapper(manifest)
+		if err != nil {
+			t.Errorf("Error parsing manifest: %s", err)
+		}
+		assert.Equal(t, string(expectedManifest), string(wrapper))
+	})
+}

--- a/backend/api/kubeneat/testdata/expected/multi_manifest.yaml
+++ b/backend/api/kubeneat/testdata/expected/multi_manifest.yaml
@@ -1,0 +1,257 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podtato-kubectl
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-entry
+  namespace: podtato-kubectl
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-entry
+  template:
+    metadata:
+      labels:
+        component: podtato-head-entry
+    spec:
+      containers:
+      - env:
+        - name: PODTATO_PORT
+          value: "9000"
+        image: ghcr.io/podtato-head/entry:0.2.1
+        imagePullPolicy: Always
+        name: server
+        ports:
+        - containerPort: 9000
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-entry
+  namespace: podtato-kubectl
+spec:
+  ports:
+  - name: http
+    port: 9000
+  selector:
+    component: podtato-head-entry
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-hat
+  namespace: podtato-kubectl
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-hat
+  template:
+    metadata:
+      labels:
+        component: podtato-head-hat
+    spec:
+      containers:
+      - env:
+        - name: PODTATO_PORT
+          value: "9000"
+        image: ghcr.io/podtato-head/hat:0.2.1
+        imagePullPolicy: Always
+        name: server
+        ports:
+        - containerPort: 9000
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-hat
+  namespace: podtato-kubectl
+spec:
+  ports:
+  - name: http
+    port: 9001
+    targetPort: 9000
+  selector:
+    component: podtato-head-hat
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-left-leg
+  namespace: podtato-kubectl
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-left-leg
+  template:
+    metadata:
+      labels:
+        component: podtato-head-left-leg
+    spec:
+      containers:
+      - env:
+        - name: PODTATO_PORT
+          value: "9000"
+        image: ghcr.io/podtato-head/left-leg:0.2.1
+        imagePullPolicy: Always
+        name: server
+        ports:
+        - containerPort: 9000
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-left-leg
+  namespace: podtato-kubectl
+spec:
+  ports:
+  - name: http
+    port: 9002
+    targetPort: 9000
+  selector:
+    component: podtato-head-left-leg
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-left-arm
+  namespace: podtato-kubectl
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-left-arm
+  template:
+    metadata:
+      labels:
+        component: podtato-head-left-arm
+    spec:
+      containers:
+      - env:
+        - name: PODTATO_PORT
+          value: "9000"
+        image: ghcr.io/podtato-head/left-arm:0.2.1
+        imagePullPolicy: Always
+        name: server
+        ports:
+        - containerPort: 9000
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-left-arm
+  namespace: podtato-kubectl
+spec:
+  ports:
+  - name: http
+    port: 9003
+    targetPort: 9000
+  selector:
+    component: podtato-head-left-arm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-right-leg
+  namespace: podtato-kubectl
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-right-leg
+  template:
+    metadata:
+      labels:
+        component: podtato-head-right-leg
+    spec:
+      containers:
+      - env:
+        - name: PODTATO_PORT
+          value: "9000"
+        image: ghcr.io/podtato-head/right-leg:0.2.1
+        imagePullPolicy: Always
+        name: server
+        ports:
+        - containerPort: 9000
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-right-leg
+  namespace: podtato-kubectl
+spec:
+  ports:
+  - name: http
+    port: 9004
+    targetPort: 9000
+  selector:
+    component: podtato-head-right-leg
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-right-arm
+  namespace: podtato-kubectl
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-right-arm
+  template:
+    metadata:
+      labels:
+        component: podtato-head-right-arm
+    spec:
+      containers:
+      - env:
+        - name: PODTATO_PORT
+          value: "9000"
+        image: ghcr.io/podtato-head/right-arm:0.2.1
+        imagePullPolicy: Always
+        name: server
+        ports:
+        - containerPort: 9000
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: podtato-head
+  name: podtato-head-right-arm
+  namespace: podtato-kubectl
+spec:
+  ports:
+  - name: http
+    port: 9005
+    targetPort: 9000
+  selector:
+    component: podtato-head-right-arm

--- a/backend/api/kubeneat/testdata/expected/single_manifest.yaml
+++ b/backend/api/kubeneat/testdata/expected/single_manifest.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx-deployment
+  namespace: example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx:1.14.2
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/backend/api/kubeneat/testdata/multi_manifest.yaml
+++ b/backend/api/kubeneat/testdata/multi_manifest.yaml
@@ -1,0 +1,271 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podtato-kubectl
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podtato-head-entry
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-entry
+  template:
+    metadata:
+      labels:
+        component: podtato-head-entry
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: server
+          image: ghcr.io/podtato-head/entry:0.2.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+          env:
+            - name: PODTATO_PORT
+              value: "9000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-entry
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-entry
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  type: LoadBalancer
+  # change to NodePort if no LoadBalancer controller is available
+  # type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podtato-head-hat
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-hat
+  template:
+    metadata:
+      labels:
+        component: podtato-head-hat
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: server
+          image: ghcr.io/podtato-head/hat:0.2.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+          env:
+            - name: PODTATO_PORT
+              value: "9000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-hat
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-hat
+  ports:
+    - name: http
+      port: 9001
+      protocol: TCP
+      targetPort: 9000
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podtato-head-left-leg
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-left-leg
+  template:
+    metadata:
+      labels:
+        component: podtato-head-left-leg
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: server
+          image: ghcr.io/podtato-head/left-leg:0.2.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+          env:
+            - name: PODTATO_PORT
+              value: "9000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-left-leg
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-left-leg
+  ports:
+    - name: http
+      port: 9002
+      protocol: TCP
+      targetPort: 9000
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podtato-head-left-arm
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-left-arm
+  template:
+    metadata:
+      labels:
+        component: podtato-head-left-arm
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: server
+          image: ghcr.io/podtato-head/left-arm:0.2.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+          env:
+            - name: PODTATO_PORT
+              value: "9000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-left-arm
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-left-arm
+  ports:
+    - name: http
+      port: 9003
+      protocol: TCP
+      targetPort: 9000
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podtato-head-right-leg
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-right-leg
+  template:
+    metadata:
+      labels:
+        component: podtato-head-right-leg
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: server
+          image: ghcr.io/podtato-head/right-leg:0.2.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+          env:
+            - name: PODTATO_PORT
+              value: "9000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-right-leg
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-right-leg
+  ports:
+    - name: http
+      port: 9004
+      protocol: TCP
+      targetPort: 9000
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podtato-head-right-arm
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-right-arm
+  template:
+    metadata:
+      labels:
+        component: podtato-head-right-arm
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: server
+          image: ghcr.io/podtato-head/right-arm:0.2.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+          env:
+            - name: PODTATO_PORT
+              value: "9000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-right-arm
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-right-arm
+  ports:
+    - name: http
+      port: 9005
+      protocol: TCP
+      targetPort: 9000
+  type: ClusterIP

--- a/backend/api/kubeneat/testdata/single_manifest.yaml
+++ b/backend/api/kubeneat/testdata/single_manifest.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: example
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          args: []
+          ports:
+            - containerPort: 80
+          resources: {}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/onsi/gomega v1.16.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.2.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -50,6 +51,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.20.6 // indirect
 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
 	k8s.io/apimachinery v0.20.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -620,6 +620,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -1243,6 +1244,7 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v0.3.5/go.mod h1:Mnf3e5FUzXbkCfynWBGOwLssY7gTQgCHObK9tMpAriY=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=


### PR DESCRIPTION
This PR adds multi manifest file support

Sometimes, especially with `helm template` you have multiple yaml files in one single file seperated by `---`

example -> https://github.com/podtato-head/podtato-head/blob/main/delivery/kubectl/manifest.yaml

This PR splits them into single manifests so that kubeneat can process them (needs json as input) and put them back again into one output file.

![image](https://user-images.githubusercontent.com/38325136/153941934-02787554-e086-4b67-a299-4830eece3229.png)

hope you like it!