### PR TITLE
Update index.tsx

### DIFF
--- a/frontend/src/components/MainView/index.tsx
+++ b/frontend/src/components/MainView/index.tsx
@@ -10,10 +10,6 @@ import MyYaml from "./YamlBox/ExistingYaml";
 import NewYaml from "./YamlBox/NewYaml";
 
 const TextAreaContainer = styled.div`
-  display: grid;
-  grid-column-gap: 4rem;
-  grid-row-gap: 3rem;
-  align-items: self-end;
   @media (min-width: 74rem) {
     grid-template-columns: 1fr 1fr;
     justify-content: center;


### PR DESCRIPTION
Updated issue#53 : yaml textbox overflows in mobile view #53

The text box has been sized to fit the width of the screen in order to prevent it from overflowing and being scrolled and viewed. 
