### PR TITLE
added a redirecting link to the githublogo

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,18 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-  <!-- Google Tag Manager -->
+    <!-- Google Tag Manager -->
     <script>
-    (function(w,d,s,l,i){
-      w[l]=w[l]||[];
-      w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-      var f = d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-      j.async=true;
-      j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-      f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-MCMRL6S');
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-MCMRL6S");
     </script>
-  <!-- End Google Tag Manager -->
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
     <link rel="canonical" href="https://validkube.com/" />
@@ -23,11 +25,17 @@
       content="ValidKube combines the best open-source tools to help ensure Kubernetes YAML best practices, hygiene & security."
     />
     <link
-    href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;500&family=Roboto:wght@400;500;700;900&display=swap"
-    rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;500&family=Roboto:wght@400;500;700;900&display=swap"
+      rel="stylesheet"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -47,7 +55,12 @@
   <body>
     <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MCMRL6S" height="0" width="0" style="display:none;visibility:hidden">
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MCMRL6S"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      >
       </iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->

--- a/frontend/src/components/GenericComponents/Tabs.tsx
+++ b/frontend/src/components/GenericComponents/Tabs.tsx
@@ -6,10 +6,10 @@ const TabsContainer = styled.div`
   margin-bottom: 0.8rem;
   -ms-overflow-style: none;
   scrollbar-width: none;
-  @media only screen and (max-width: 600px){
+  @media only screen and (max-width: 600px) {
     width: 85vw;
     overflow-x: scroll;
-  }  
+  }
   ::-webkit-scrollbar {
     display: none;
   }

--- a/frontend/src/components/MainView/MainViewHeader.tsx
+++ b/frontend/src/components/MainView/MainViewHeader.tsx
@@ -15,6 +15,7 @@ import { ThemePreference } from "../Context/ThemeContext";
 export const KOMODOR_COM = "https://komodor.com/";
 export const TWITTER_URL = "https://twitter.com/Komodor_com";
 export const LINKEDIN_URL = "https://www.linkedin.com/company/komodor-ltd/";
+export const GITHUB_URL = "https://github.com/komodorio";
 
 const Container = styled.div`
   padding: 1% 1.5%;
@@ -29,6 +30,7 @@ const Container = styled.div`
 const GitContainer = styled.div`
   align-items: center;
   display: flex;
+  cursor: pointer;
   @media (max-width: 30rem) {
     padding-left: 1.5rem;
   }
@@ -109,7 +111,7 @@ const MainViewHeader: React.FC = () => {
             <TwitterIcon onClick={() => window.open(TWITTER_URL)} />
           </SocialButtonContainer>
           <GitContainer>
-            <GitIcon />
+            <GitIcon onClick={() => window.open(GITHUB_URL)}/>
             <GitHubButton
               href="https://github.com/komodorio/validkube"
               data-color-scheme="no-preference: light; light: light; dark: light;"

--- a/frontend/src/components/MainView/YamlBox/YamlBoxComponents.tsx
+++ b/frontend/src/components/MainView/YamlBox/YamlBoxComponents.tsx
@@ -27,7 +27,7 @@ export const StyledTextAreaCss = {
 export const TextAreaContainer = styled.div`
   border: 1px solid ${greyBorder};
   width: 100%;
-  @media only screen and (max-width: 600px){
+  @media only screen and (max-width: 600px) {
     width: 85vw;
   }
 `;

--- a/frontend/src/components/MainView/index.tsx
+++ b/frontend/src/components/MainView/index.tsx
@@ -20,7 +20,7 @@ const TextAreaContainer = styled.div`
     grid-auto-flow: column;
   }
   padding: 2% 8% 3% 8%;
-  @media only screen and (max-width: 600px){
+  @media only screen and (max-width: 600px) {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,13 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }

--- a/frontend/src/reportWebVitals.ts
+++ b/frontend/src/reportWebVitals.ts
@@ -1,8 +1,8 @@
-import { ReportHandler } from 'web-vitals';
+import { ReportHandler } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);
       getFCP(onPerfEntry);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
This is a PR regarding [Issue #64 ](https://github.com/komodorio/validkube/issues/64) .
In which the Github logo at the top right corner was unfuntional. 
By adding the following changes, it will help the user redirect to the Komodorio GitHub page by clicking on it.